### PR TITLE
Fix an error when one of the macros is called from other applications

### DIFF
--- a/lib/oop.ex
+++ b/lib/oop.ex
@@ -125,8 +125,12 @@ defmodule OOP do
     defmethod!(name, block)
   end
 
-  defmacro def({ name, _, params }, do: block) do
+  defmacro def({ name, _, params }, do: block) when is_list(params) do
     defmethod!(name, params, block)
+  end
+
+  defmacro def({ name, _, param }, do: block) do
+    defmethod!(name, [param], block)
   end
 
   defmacro defp({ :when, _, [{ name, _, params }|guards] }, do: block) do
@@ -137,8 +141,12 @@ defmodule OOP do
     defmethodp!(name, block)
   end
 
-  defmacro defp({ name, _, params }, do: block) do
+  defmacro defp({ name, _, params }, do: block) when is_list(params) do
     defmethodp!(name, params, block)
+  end
+
+  defmacro defp({ name, _, param }, do: block) do
+    defmethodp!(name, [param], block)
   end
 
   defmacro @({ attr, _, nil }) do


### PR DESCRIPTION
```
** (ArgumentError) expected a list with quoted expressions in unquote_splicing/1, got: OOP
    (elixir) src/elixir_quote.erl:119: :elixir_quote.argument_error/1
    (elixir) src/elixir_quote.erl:100: :elixir_quote.list/2
      lib/oop.ex:204: OOP.defmethod!/3
      expanding macro: OOP.def/2
      lib/oop_demo.ex:4: OopDemo.LULZ (module)
      (elixir) expanding macro: Kernel.if/2
      lib/oop_demo.ex:4: OopDemo.LULZ (module)
```
